### PR TITLE
Initialize Next.js + Tailwind MVP skeleton

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,7 @@
+# Alpaca
+ALPACA_API_KEY=
+ALPACA_API_SECRET=
+ALPACA_BASE_URL=
+
+# Financial Modeling Prep
+FMP_API_KEY=

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ["next/core-web-vitals", "prettier"]
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# dependencies
+node_modules
+
+# Next.js
+.next
+out
+
+# production
+build
+
+# misc
+.DS_Store
+*.pem
+
+# env
+.env.local
+.env
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# vercel
+.vercel

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+out
+build

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  semi: true,
+  singleQuote: false,
+  trailingComma: "none",
+  printWidth: 100,
+  plugins: ["prettier-plugin-tailwindcss"]
+};

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,21 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  background: linear-gradient(180deg, #f4f1ea 0%, #ffffff 40%, #f4f1ea 100%);
+  color: #0b0d12;
+  min-height: 100vh;
+}
+
+main {
+  width: min(1100px, 92vw);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Hercules",
+  description: "Options income qualifier"
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen">
+        <div className="flex min-h-screen flex-col">
+          <header className="border-b border-black/10 bg-white/70 backdrop-blur">
+            <div className="mx-auto flex w-full max-w-[1100px] items-center justify-between px-4 py-4">
+              <div className="flex items-center gap-3">
+                <div className="h-8 w-8 rounded-full border border-black/10 bg-ember" />
+                <span className="text-sm font-semibold tracking-[0.2em] text-ink">
+                  HERCULES
+                </span>
+              </div>
+              <nav className="flex items-center gap-6 text-sm text-black/70">
+                <span>Dashboard</span>
+                <span>Screeners</span>
+                <span>Risk</span>
+              </nav>
+            </div>
+          </header>
+          <main className="mx-auto flex w-full flex-1 flex-col gap-10 px-4 py-10">
+            {children}
+          </main>
+          <footer className="border-t border-black/10 bg-white/80">
+            <div className="mx-auto flex w-full max-w-[1100px] items-center justify-between px-4 py-6 text-xs text-black/60">
+              <span>Built for disciplined income.</span>
+              <span>Hercules MVP</span>
+            </div>
+          </footer>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,52 @@
+export default function HomePage() {
+  return (
+    <section className="grid gap-8">
+      <div className="rounded-3xl border border-black/10 bg-white/90 p-8 shadow-sm">
+        <p className="text-xs uppercase tracking-[0.35em] text-black/50">
+          Options income qualifier
+        </p>
+        <h1 className="mt-4 text-4xl font-semibold text-ink md:text-5xl">
+          Underwrite options trades with discipline.
+        </h1>
+        <p className="mt-4 max-w-2xl text-base leading-relaxed text-black/70">
+          Hercules ranks and explains sell-side opportunities, filtering out weak fundamentals and
+          fragile liquidity before premium ever enters the conversation.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3 text-sm">
+          <span className="rounded-full bg-ember/10 px-4 py-2 text-ember">Market-first bias</span>
+          <span className="rounded-full bg-black/5 px-4 py-2 text-black/70">
+            30-60 DTE focus
+          </span>
+          <span className="rounded-full bg-black/5 px-4 py-2 text-black/70">
+            Risk flags surfaced
+          </span>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        {[
+          {
+            title: "Qualify",
+            body: "Hard filters on liquidity, volatility, and assignment quality."
+          },
+          {
+            title: "Rank",
+            body: "Weighted scorecard blends fundamentals, trend, and event risk."
+          },
+          {
+            title: "Explain",
+            body: "Every candidate includes context and guardrails before execution."
+          }
+        ].map((item) => (
+          <div
+            key={item.title}
+            className="rounded-2xl border border-black/10 bg-white/80 p-6"
+          >
+            <h2 className="text-lg font-semibold text-ink">{item.title}</h2>
+            <p className="mt-2 text-sm text-black/70">{item.body}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "hercules",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "format": "prettier --check .",
+    "format:write": "prettier --write ."
+  },
+  "dependencies": {
+    "next": "^14.2.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.0",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.0",
+    "eslint-config-prettier": "^9.1.0",
+    "postcss": "^8.4.0",
+    "prettier": "^3.2.0",
+    "prettier-plugin-tailwindcss": "^0.6.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{js,ts,jsx,tsx,mdx}", "./components/**/*.{js,ts,jsx,tsx,mdx}"],
+  theme: {
+    extend: {
+      colors: {
+        ink: "#0b0d12",
+        haze: "#f4f1ea",
+        ember: "#f25f4c"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize Next.js App Router with TypeScript and TailwindCSS
- add ESLint + Prettier config and formatting scripts
- add basic layout shell (header/content/footer)
- include `.env.local.example` with Alpaca + FMP placeholders

## Testing
- not run (no dependencies installed yet)

## Notes
- `main` now contains the MVP PRD baseline commit to allow this PR