### PR TITLE
Add score engine v1 with breakdown

### DIFF
--- a/app/api/scoring/score/route.ts
+++ b/app/api/scoring/score/route.ts
@@ -1,0 +1,15 @@
+import type { ScoreInput } from "@/src/lib/scoring/engine";
+import { scoreCandidate } from "@/src/lib/scoring/engine";
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as ScoreInput;
+    const result = scoreCandidate(body);
+    return Response.json(result);
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Invalid request" },
+      { status: 400 }
+    );
+  }
+}

--- a/src/lib/scoring/engine.ts
+++ b/src/lib/scoring/engine.ts
@@ -1,0 +1,111 @@
+import type { Fundamentals, LiquidityGateResult, RiskFlag, ScoreBreakdown } from "@/src/lib/types";
+
+export type ScoreInput = {
+  fundamentals: Fundamentals | null;
+  liquidityGate: LiquidityGateResult | null;
+  impliedVol: number | null;
+  trendScore: number | null;
+  eventRiskFlags: RiskFlag[];
+};
+
+export type ScoreConfig = {
+  fundamentalsWeight: number;
+  liquidityWeight: number;
+  volatilityWeight: number;
+  technicalWeight: number;
+  eventWeight: number;
+};
+
+export type ScoreResult = {
+  total: number;
+  breakdown: ScoreBreakdown;
+  riskFlags: RiskFlag[];
+  interpretation: "HIGH" | "ACCEPTABLE" | "PASS";
+};
+
+export const DEFAULT_SCORE_CONFIG: ScoreConfig = {
+  fundamentalsWeight: 30,
+  liquidityWeight: 20,
+  volatilityWeight: 20,
+  technicalWeight: 20,
+  eventWeight: 10
+};
+
+const clamp = (value: number, min = 0, max = 100) => Math.max(min, Math.min(max, value));
+
+const scoreFundamentals = (fundamentals: Fundamentals | null, weight: number) => {
+  if (!fundamentals) return 0;
+
+  let score = 0;
+
+  if (fundamentals.marketCap && fundamentals.marketCap >= 10_000_000_000) score += 0.3;
+  if (fundamentals.returnOnEquity && fundamentals.returnOnEquity > 0) score += 0.2;
+  if (fundamentals.netMargin && fundamentals.netMargin > 0) score += 0.2;
+  if (fundamentals.debtToEquity !== null && fundamentals.debtToEquity < 2) score += 0.2;
+  if (fundamentals.currentRatio !== null && fundamentals.currentRatio > 1) score += 0.1;
+
+  return clamp(score * weight, 0, weight);
+};
+
+const scoreLiquidity = (liquidityGate: LiquidityGateResult | null, weight: number) => {
+  if (!liquidityGate) return weight * 0.5;
+  return liquidityGate.passed ? weight : weight * 0.2;
+};
+
+const scoreVolatility = (impliedVol: number | null, weight: number) => {
+  if (impliedVol === null) return weight * 0.4;
+  if (impliedVol >= 0.5) return weight * 0.9;
+  if (impliedVol >= 0.3) return weight * 0.7;
+  if (impliedVol >= 0.2) return weight * 0.5;
+  return weight * 0.3;
+};
+
+const scoreTechnical = (trendScore: number | null, weight: number) => {
+  if (trendScore === null) return weight * 0.5;
+  const normalized = clamp(trendScore, 0, 1);
+  return normalized * weight;
+};
+
+const scoreEventRisk = (riskFlags: RiskFlag[], weight: number) => {
+  if (riskFlags.length === 0) return weight;
+  return clamp(weight - riskFlags.length * 2, 0, weight);
+};
+
+const interpretScore = (total: number): ScoreResult["interpretation"] => {
+  if (total >= 80) return "HIGH";
+  if (total >= 65) return "ACCEPTABLE";
+  return "PASS";
+};
+
+export const scoreCandidate = (
+  input: ScoreInput,
+  config: ScoreConfig = DEFAULT_SCORE_CONFIG
+): ScoreResult => {
+  const fundamentalsScore = scoreFundamentals(input.fundamentals, config.fundamentalsWeight);
+  const liquidityScore = scoreLiquidity(input.liquidityGate, config.liquidityWeight);
+  const volatilityScore = scoreVolatility(input.impliedVol, config.volatilityWeight);
+  const technicalScore = scoreTechnical(input.trendScore, config.technicalWeight);
+  const eventScore = scoreEventRisk(input.eventRiskFlags, config.eventWeight);
+
+  const total = clamp(
+    fundamentalsScore + liquidityScore + volatilityScore + technicalScore + eventScore,
+    0,
+    100
+  );
+
+  const breakdown: ScoreBreakdown = {
+    fundamentals: Math.round(fundamentalsScore),
+    liquidity: Math.round(liquidityScore),
+    volatility: Math.round(volatilityScore),
+    trend: Math.round(technicalScore),
+    eventRisk: Math.round(eventScore),
+    total: Math.round(total)
+  };
+
+  return {
+    total: breakdown.total,
+    breakdown,
+    riskFlags: input.eventRiskFlags,
+    interpretation: interpretScore(breakdown.total)
+  };
+};


### PR DESCRIPTION
## Summary
- implement score engine with configurable weights
- return breakdown + interpretation bands + risk flags
- expose POST `/api/scoring/score`

## Testing
- not run (no test runner configured)

## Notes
- fundamentals/liquidity/vol/technical/event weights default to 30/20/20/20/10