### PR TITLE
Add strategy selector (CSP/PCS/CCS/CC)

### DIFF
--- a/app/api/strategy/select/route.ts
+++ b/app/api/strategy/select/route.ts
@@ -1,0 +1,15 @@
+import type { StrategySelectionInput } from "@/src/lib/strategy/selector";
+import { selectStrategies } from "@/src/lib/strategy/selector";
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as StrategySelectionInput;
+    const result = selectStrategies(body);
+    return Response.json(result);
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Invalid request" },
+      { status: 400 }
+    );
+  }
+}

--- a/src/lib/strategy/selector.ts
+++ b/src/lib/strategy/selector.ts
@@ -1,0 +1,55 @@
+import type {
+  Fundamentals,
+  MarketRegime,
+  StrategySelectionInput,
+  StrategySelectionResult,
+  StrategyType,
+  TrendMetrics
+} from "@/src/lib/types";
+import { deriveRegime } from "@/src/lib/scoring/trend";
+
+// types are re-exported in src/lib/types/strategy.ts
+
+const isHoldable = (fundamentals: Fundamentals | null) => {
+  if (!fundamentals) return false;
+  if (fundamentals.marketCap !== null && fundamentals.marketCap < 5_000_000_000) return false;
+  if (fundamentals.debtToEquity !== null && fundamentals.debtToEquity > 2.5) return false;
+  if (fundamentals.currentRatio !== null && fundamentals.currentRatio < 1) return false;
+  return true;
+};
+
+export const selectStrategies = (
+  input: StrategySelectionInput
+): StrategySelectionResult => {
+  const marketRegime = deriveRegime(input.marketTrend);
+  const stockRegime = deriveRegime(input.stockTrend);
+  const assignmentEligible = isHoldable(input.fundamentals);
+
+  const biasDefinedRisk = input.preferDefinedRisk ?? !assignmentEligible;
+
+  const bullishOrNeutral = marketRegime !== "BEAR" && stockRegime !== "BEAR";
+  const neutralOrBearish = marketRegime !== "BULL" || stockRegime !== "BULL";
+
+  const strategies = new Set<StrategyType>();
+
+  if (bullishOrNeutral) {
+    strategies.add("PCS");
+    if (!biasDefinedRisk) {
+      strategies.add("CSP");
+    }
+  }
+
+  if (neutralOrBearish) {
+    strategies.add("CCS");
+    if (!biasDefinedRisk) {
+      strategies.add("CC");
+    }
+  }
+
+  return {
+    strategies: Array.from(strategies),
+    marketRegime,
+    stockRegime,
+    assignmentEligible
+  };
+};

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -24,3 +24,4 @@ export type {
 } from "./liquidity";
 export type { VolatilityMetrics } from "./volatility";
 export type { MarketRegime, TrendMetrics, TrendScoreResult } from "./trend";
+export type { StrategySelectionInput, StrategySelectionResult } from "./strategy";

--- a/src/lib/types/strategy.ts
+++ b/src/lib/types/strategy.ts
@@ -1,3 +1,15 @@
-export type StrategyType = "CSP" | "PCS" | "CCS" | "CC";
+import type { Fundamentals, MarketRegime, StrategyType, TrendMetrics } from "@/src/lib/types";
 
-export type OptionSide = "put" | "call";
+export type StrategySelectionInput = {
+  marketTrend: TrendMetrics;
+  stockTrend: TrendMetrics;
+  fundamentals: Fundamentals | null;
+  preferDefinedRisk?: boolean;
+};
+
+export type StrategySelectionResult = {
+  strategies: StrategyType[];
+  marketRegime: MarketRegime;
+  stockRegime: MarketRegime;
+  assignmentEligible: boolean;
+};


### PR DESCRIPTION
## Summary
- implement strategy selector using market + stock regime and assignment suitability
- bias toward defined-risk spreads unless fundamentals are holdable
- expose POST `/api/strategy/select`

## Testing
- not run (no test runner configured)

## Notes
- uses SPY/QQQ market regime inputs from trend metrics
- `preferDefinedRisk` can override assignment eligibility