### PR TITLE
Add DTE filter + expiration ranking

### DIFF
--- a/app/api/expiry/rank/route.ts
+++ b/app/api/expiry/rank/route.ts
@@ -1,0 +1,19 @@
+import type { ExpirationCandidate, ExpirationRankingConfig } from "@/src/lib/types/expiry";
+import { rankExpirations } from "@/src/lib/expiry/ranker";
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as {
+      candidates: ExpirationCandidate[];
+      config?: Partial<ExpirationRankingConfig>;
+    };
+
+    const result = rankExpirations(body.candidates, body.config);
+    return Response.json(result);
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Invalid request" },
+      { status: 400 }
+    );
+  }
+}

--- a/src/lib/expiry/ranker.ts
+++ b/src/lib/expiry/ranker.ts
@@ -1,0 +1,48 @@
+import type { ExpirationCandidate, ExpirationRanked, ExpirationRankingConfig } from "@/src/lib/types/expiry";
+
+const DEFAULT_CONFIG: ExpirationRankingConfig = {
+  minDte: 30,
+  maxDte: 60,
+  softMinDte: 25,
+  softMaxDte: 70,
+  eventPenalty: 0.15,
+  topN: 3
+};
+
+const clamp = (value: number, min = 0, max = 1) => Math.max(min, Math.min(max, value));
+
+const dteScore = (dte: number, config: ExpirationRankingConfig) => {
+  if (dte >= config.minDte && dte <= config.maxDte) return 1;
+  if (dte >= config.softMinDte && dte <= config.softMaxDte) return 0.6;
+  return 0.2;
+};
+
+const efficiencyScore = (thetaPerDay: number, credit: number, maxLoss: number) => {
+  const creditPerRisk = maxLoss > 0 ? credit / maxLoss : 0;
+  const thetaFactor = clamp(thetaPerDay / 1, 0, 1);
+  const creditFactor = clamp(creditPerRisk / 0.5, 0, 1);
+  return 0.5 * thetaFactor + 0.5 * creditFactor;
+};
+
+export const rankExpirations = (
+  candidates: ExpirationCandidate[],
+  config: Partial<ExpirationRankingConfig> = {}
+) => {
+  const cfg = { ...DEFAULT_CONFIG, ...config };
+
+  const ranked: ExpirationRanked[] = candidates.map((candidate) => {
+    const base = dteScore(candidate.dte, cfg);
+    const efficiency = efficiencyScore(candidate.thetaPerDay, candidate.credit, candidate.maxLoss);
+    const hasEventRisk = candidate.riskFlags.length > 0;
+    const penalty = hasEventRisk ? cfg.eventPenalty : 0;
+
+    const score = clamp(base * 0.6 + efficiency * 0.4 - penalty, 0, 1);
+
+    return {
+      ...candidate,
+      score
+    };
+  });
+
+  return ranked.sort((a, b) => b.score - a.score).slice(0, cfg.topN);
+};

--- a/src/lib/types/expiry.ts
+++ b/src/lib/types/expiry.ts
@@ -1,0 +1,24 @@
+import type { RiskFlag, StrategyType } from "@/src/lib/types";
+
+export type ExpirationCandidate = {
+  expiration: string;
+  dte: number;
+  thetaPerDay: number;
+  credit: number;
+  maxLoss: number;
+  riskFlags: RiskFlag[];
+  strategy: StrategyType;
+};
+
+export type ExpirationRanked = ExpirationCandidate & {
+  score: number;
+};
+
+export type ExpirationRankingConfig = {
+  minDte: number;
+  maxDte: number;
+  softMinDte: number;
+  softMaxDte: number;
+  eventPenalty: number;
+  topN: number;
+};

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -26,3 +26,4 @@ export type { VolatilityMetrics } from "./volatility";
 export type { MarketRegime, TrendMetrics, TrendScoreResult } from "./trend";
 export type { StrategySelectionInput, StrategySelectionResult } from "./strategy";
 export type { StrikeCandidate, StrikeFinderConfig, StrikeFinderReason } from "./strike";
+export type { ExpirationCandidate, ExpirationRanked, ExpirationRankingConfig } from "./expiry";


### PR DESCRIPTION
## Summary
- add expiration candidate types + ranking logic
- rank by DTE window, theta/day efficiency, credit per risk, and event penalties
- expose POST `/api/expiry/rank`

## Testing
- not run (no test runner configured)

## Notes
- default window 30–60 DTE; soft window 25–70 (ranked lower)
- returns top N candidates (default 3)