### PR TITLE
Add explanation builder for risk flags + why bullets

### DIFF
--- a/app/api/explain/build/route.ts
+++ b/app/api/explain/build/route.ts
@@ -1,0 +1,15 @@
+import type { ExplanationInput } from "@/src/lib/types/explain";
+import { buildExplanation } from "@/src/lib/explain/builder";
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as ExplanationInput;
+    const result = buildExplanation(body);
+    return Response.json(result);
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Invalid request" },
+      { status: 400 }
+    );
+  }
+}

--- a/src/lib/explain/builder.ts
+++ b/src/lib/explain/builder.ts
@@ -1,0 +1,94 @@
+import type { ExplanationInput, ExplanationResult } from "@/src/lib/types/explain";
+import type { RiskFlag } from "@/src/lib/types";
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+const formatPct = (value: number) => `${(value * 100).toFixed(0)}%`;
+
+const formatNumber = (value: number) =>
+  Intl.NumberFormat("en-US", { notation: "compact", maximumFractionDigits: 1 }).format(value);
+
+const unique = <T>(items: T[]) => Array.from(new Set(items));
+
+const buildWhyBullets = (input: ExplanationInput): string[] => {
+  const bullets: string[] = [];
+
+  if (input.volatility?.iv !== null) {
+    const regime = input.volatility.ivRegime.toLowerCase();
+    bullets.push(`IV at ${formatPct(input.volatility.iv)} with ${regime} trend.`);
+  }
+
+  if (input.strike) {
+    const otmPct =
+      input.underlyingPrice && input.underlyingPrice > 0
+        ? Math.abs((input.underlyingPrice - input.strike.shortStrike) / input.underlyingPrice)
+        : null;
+    const delta = input.strike.shortDelta !== null ? input.strike.shortDelta.toFixed(2) : "n/a";
+    bullets.push(`Short strike ${input.strike.shortStrike} at ${delta} delta.`);
+    if (otmPct !== null) {
+      bullets.push(`Short strike ${formatPct(otmPct)} OTM.`);
+    }
+  }
+
+  if (input.tradeDte !== null) {
+    bullets.push(`Targeting ${input.tradeDte} DTE window.`);
+  }
+
+  if (input.liquidity?.diagnostics.avgDailyVolume !== null) {
+    const vol = input.liquidity.diagnostics.avgDailyVolume;
+    bullets.push(`Average daily volume ${formatNumber(vol)} shares.`);
+  }
+
+  if (input.fundamentals?.marketCap !== null) {
+    bullets.push(`Market cap ${formatNumber(input.fundamentals.marketCap)}.`);
+  }
+
+  if (input.trend) {
+    bullets.push(`Price vs 200DMA: ${formatPct(input.trend.distanceFrom200DmaPct / 100)}.`);
+  }
+
+  if (input.calendar?.earnings?.daysToEarnings !== null) {
+    const days = input.calendar.earnings.daysToEarnings;
+    const horizon = input.tradeDte ?? 21;
+    if (days > horizon) {
+      bullets.push(`No earnings within ${horizon} days.`);
+    } else {
+      bullets.push(`Earnings in ${days} days.`);
+    }
+  } else if (input.calendar) {
+    bullets.push("No upcoming earnings on calendar.");
+  }
+
+  return bullets;
+};
+
+export const buildExplanation = (input: ExplanationInput): ExplanationResult => {
+  const rawBullets = buildWhyBullets(input);
+  const riskFlags = new Set<RiskFlag>(input.riskFlags ?? []);
+  if (input.calendar?.macroEvents && input.calendar.macroEvents.length > 0) {
+    riskFlags.add("RISK_MACRO_EVENT");
+  }
+  if (input.calendar?.earnings?.daysToEarnings !== null && input.tradeDte !== null) {
+    if (input.calendar.earnings.daysToEarnings <= input.tradeDte) {
+      riskFlags.add("RISK_EARNINGS_WITHIN_TRADE");
+    }
+  }
+
+  const prioritized = rawBullets.filter(Boolean);
+  const limited = prioritized.slice(0, 6);
+
+  const filled = [...limited];
+  if (filled.length < 3) {
+    if (input.score) {
+      filled.push(`Score ${input.score.total}/100 with balanced breakdown.`);
+    }
+    if (filled.length < 3) {
+      filled.push("Meets baseline filters for strategy evaluation.");
+    }
+  }
+
+  return {
+    why: filled.slice(0, 6),
+    riskFlags: Array.from(riskFlags)
+  };
+};

--- a/src/lib/types/explain.ts
+++ b/src/lib/types/explain.ts
@@ -1,0 +1,29 @@
+import type {
+  CalendarSnapshot,
+  Fundamentals,
+  LiquidityGateResult,
+  RiskFlag,
+  ScoreBreakdown,
+  StrikeCandidate,
+  TrendMetrics,
+  VolatilityMetrics
+} from "@/src/lib/types";
+
+export type ExplanationInput = {
+  ticker: string;
+  underlyingPrice?: number | null;
+  score?: ScoreBreakdown | null;
+  volatility?: VolatilityMetrics | null;
+  strike?: StrikeCandidate | null;
+  liquidity?: LiquidityGateResult | null;
+  fundamentals?: Fundamentals | null;
+  trend?: TrendMetrics | null;
+  calendar?: CalendarSnapshot | null;
+  tradeDte?: number | null;
+  riskFlags?: RiskFlag[];
+};
+
+export type ExplanationResult = {
+  why: string[];
+  riskFlags: RiskFlag[];
+};

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -27,3 +27,4 @@ export type { MarketRegime, TrendMetrics, TrendScoreResult } from "./trend";
 export type { StrategySelectionInput, StrategySelectionResult } from "./strategy";
 export type { StrikeCandidate, StrikeFinderConfig, StrikeFinderReason } from "./strike";
 export type { ExpirationCandidate, ExpirationRanked, ExpirationRankingConfig } from "./expiry";
+export type { ExplanationInput, ExplanationResult } from "./explain";


### PR DESCRIPTION
## Summary
- add deterministic explanation builder for 3–6 “why” bullets
- include risk flag aggregation (earnings + macro) and optional metrics
- expose POST `/api/explain/build`

## Testing
- not run (no test runner configured)

## Notes
- supports optional inputs: volatility, strike, trend, liquidity, calendar, score