### PR TITLE
Add account sizing guardrail (5% max)

### DIFF
--- a/app/api/sizing/check/route.ts
+++ b/app/api/sizing/check/route.ts
@@ -1,0 +1,15 @@
+import type { PositionSizingInput } from "@/src/lib/types/sizing";
+import { evaluatePositionSizing } from "@/src/lib/sizing/guardrail";
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as PositionSizingInput;
+    const result = evaluatePositionSizing(body);
+    return Response.json(result);
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Invalid request" },
+      { status: 400 }
+    );
+  }
+}

--- a/src/lib/sizing/guardrail.ts
+++ b/src/lib/sizing/guardrail.ts
@@ -1,0 +1,24 @@
+import type { PositionSizingInput, PositionSizingResult } from "@/src/lib/types/sizing";
+
+const DEFAULT_MAX_ALLOCATION = 0.05;
+
+export const evaluatePositionSizing = (
+  input: PositionSizingInput
+): PositionSizingResult => {
+  const maxAllocationPct = input.maxAllocationPct ?? DEFAULT_MAX_ALLOCATION;
+  const allocationPct = input.accountSize > 0 ? input.requiredCollateral / input.accountSize : 0;
+  const withinLimit = allocationPct <= maxAllocationPct;
+
+  return {
+    requiredCollateral: input.requiredCollateral,
+    accountSize: input.accountSize,
+    allocationPct,
+    maxAllocationPct,
+    withinLimit,
+    warning: withinLimit
+      ? undefined
+      : `Allocation ${Math.round(allocationPct * 100)}% exceeds ${
+          Math.round(maxAllocationPct * 100)
+        }% limit.`
+  };
+};

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -28,3 +28,4 @@ export type { StrategySelectionInput, StrategySelectionResult } from "./strategy
 export type { StrikeCandidate, StrikeFinderConfig, StrikeFinderReason } from "./strike";
 export type { ExpirationCandidate, ExpirationRanked, ExpirationRankingConfig } from "./expiry";
 export type { ExplanationInput, ExplanationResult } from "./explain";
+export type { PositionSizingInput, PositionSizingResult } from "./sizing";

--- a/src/lib/types/sizing.ts
+++ b/src/lib/types/sizing.ts
@@ -1,0 +1,14 @@
+export type PositionSizingInput = {
+  accountSize: number;
+  requiredCollateral: number;
+  maxAllocationPct?: number;
+};
+
+export type PositionSizingResult = {
+  requiredCollateral: number;
+  accountSize: number;
+  allocationPct: number;
+  maxAllocationPct: number;
+  withinLimit: boolean;
+  warning?: string;
+};


### PR DESCRIPTION
## Summary
- add position sizing guardrail based on account size + collateral
- default max allocation 5% with override option
- expose POST `/api/sizing/check`

## Testing
- not run (no test runner configured)

## Notes
- returns allocation percentage and warning when exceeded