### PR TITLE
feat: add minimum credit guardrails

### DIFF
--- a/src/lib/strategy/__tests__/strike-finder.test.ts
+++ b/src/lib/strategy/__tests__/strike-finder.test.ts
@@ -45,4 +45,27 @@ describe("strike finder", () => {
     const result = findStrikeCandidate(makeChain(contracts), 160, "PCS");
     expect(result.reasons[0]?.code).toBe("NO_VALID_SHORT_STRIKE");
   });
+
+  it("disqualifies trades below minimum credit", () => {
+    const contracts = [makeContract({ symbol: "A", strike: 145, delta: -0.2, bid: 0.2 })];
+
+    const result = findStrikeCandidate(makeChain(contracts), 160, "CSP", { minCredit: 0.3 });
+    expect(result.reasons.some((reason) => reason.code === "INSUFFICIENT_CREDIT")).toBe(true);
+  });
+
+  it("disqualifies spreads with poor credit-to-width", () => {
+    const contracts = [
+      makeContract({ symbol: "A", strike: 140, delta: -0.2, bid: 0.3, ask: 0.35 }),
+      makeContract({ symbol: "B", strike: 135, delta: -0.15, bid: 0.05, ask: 0.25 })
+    ];
+
+    const result = findStrikeCandidate(makeChain(contracts), 160, "PCS", {
+      minCredit: 0.01,
+      minCreditPct: 0.15
+    });
+
+    expect(result.reasons.some((reason) => reason.code === "POOR_CREDIT_TO_WIDTH")).toBe(
+      true
+    );
+  });
 });

--- a/src/lib/types/strike.ts
+++ b/src/lib/types/strike.ts
@@ -3,7 +3,9 @@ import type { StrategyType } from "@/src/lib/types";
 export type StrikeFinderReasonCode =
   | "NO_TRADE"
   | "NO_VALID_SHORT_STRIKE"
-  | "NO_VALID_LONG_STRIKE";
+  | "NO_VALID_LONG_STRIKE"
+  | "INSUFFICIENT_CREDIT"
+  | "POOR_CREDIT_TO_WIDTH";
 
 export type StrikeFinderReason = {
   code: StrikeFinderReasonCode;
@@ -16,6 +18,8 @@ export type StrikeFinderConfig = {
   maxSpreadPct: number;
   minOpenInterest: number;
   minVolume: number;
+  minCredit: number;
+  minCreditPct: number;
   cspMinOtmPct: number;
   cspMaxOtmPct: number;
   cspTargetDelta: number;


### PR DESCRIPTION
## Summary
- add minimum credit and credit-to-width guardrails in strike selection
- surface new disqualification reasons for low credit
- cover guardrails with strike-finder tests

## Testing
- not run (not requested)
